### PR TITLE
Add repository metadata to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Luca Palmieri <rust@lpalmieri.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "A CLI to pretty print structured logs. A Rust port of the original JavaScript bunyan CLI."
+repository = "https://github.com/LukeMathWalker/bunyan"
 
 [[bin]]
 path = "src/main.rs"


### PR DESCRIPTION
Make the source code more discoverable from crates.io and docs.rs