### PR TITLE
Fix no-color flag & error when deserializing records

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -35,11 +35,11 @@ fn main() {
 
     // Color output if explicitly requested or if the terminal supports it, unless the user
     // explicitly opted out.
-    if !cli.no_color || cli.color || atty::is(atty::Stream::Stdout) {
-        colored::control::set_override(true)
-    } else {
-        colored::control::set_override(false)
-    };
+    if cli.no_color {
+        colored::control::set_override(false);
+    } else if cli.color || atty::is(atty::Stream::Stdout) {
+        colored::control::set_override(true);
+    }
 
     process_stdin(cli.output, cli.level.0, cli.strict);
 }

--- a/src/record.rs
+++ b/src/record.rs
@@ -5,6 +5,7 @@ use itertools::Itertools;
 use serde::Serialize;
 use serde_json::ser::PrettyFormatter;
 use serde_json::Serializer;
+use std::borrow::Cow;
 use std::convert::TryFrom;
 
 #[derive(serde::Deserialize)]
@@ -28,7 +29,7 @@ pub struct LogRecord<'a> {
     pub time: DateTime<Utc>,
     /// Log message.
     #[serde(rename = "msg")]
-    pub message: &'a str,
+    pub message: Cow<'a, str>,
     /// Any extra contextual piece of information in the log record.
     #[serde(flatten)]
     pub extras: serde_json::Map<String, serde_json::Value>,


### PR DESCRIPTION
Closes #2 

Hi, I'm really new to making contributions so I'm sorry if there are some problems with the PR. I noticed an issue with the formatting of certain records while working through zero2prod (which is really awesome).

## Formatting Issues

It seems that any messages that contain escape codes are not being formatted correctly.

For example the record:
```
{"v":0,"name":"test","msg":"CREATE DATABASE \"5644bff1-6e03-4b8c-ab14-442a3dbd7723\";; rows: 0, elapsed: 83.228ms","level":30,"hostname":"foo","pid":41358,"time":"2021-03-28T18:25:01.708509+00:00","log.module_path":"sqlx::query","log.target":"sqlx::query"}
```
fails with the error:
```
Error("invalid type: string \"CREATE DATABASE \\\"fa90409f-68cf-4f6b-b25a-43ce4e5988f0\\\";; rows: 0, elapsed: 90.661ms\", expected a borrowed string", line: 1, column: 114)
```
Reading this [issue](https://github.com/serde-rs/serde/issues/1413) it seems that the `msg` needs to be unescaped (modified) in order to be parsed. After updating the code we get the output:
```
INFO: test/41403 on Foo.local: CREATE DATABASE "748c6a0d-0446-4792-baee-b06128f08746";; rows: 0, elapsed: 68.934ms (log.module_path=sqlx::query,log.target=sqlx::query)
```
 For other messages we get:
```
INFO: test/41403 on Foo.local: INSERT INTO _sqlx_migrations ( …; rows: 0, elapsed: 2.449ms

INSERT INTO
  _sqlx_migrations (
    version,
    description,
    success,
    checksum,
    execution_time
  )
VALUES
  ($1, $2, TRUE, $3, $4)
 (log.module_path=sqlx::query,log.target=sqlx::query)
```
I am not sure if this is the desired behaviour/formatting.

## no-color flag

I also noticed that the `no-color` flag doesn't seem to be working, so I've submitted a quick fix for that too.

