### PR TITLE
Add support for --condition

### DIFF
--- a/.github/workflows/publish_binaries.yml
+++ b/.github/workflows/publish_binaries.yml
@@ -18,16 +18,26 @@ jobs:
   upload-assets:
     strategy:
       matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
+        include:
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: aarch64-apple-darwin
+            os: macos-latest
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
       - uses: taiki-e/upload-rust-binary-action@v1
         with:
           bin: bunyan
+          target: ${{ matrix.target }}
           archive: $bin-$tag-$target
           tar: unix
           zip: windows

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi",
  "libc",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -77,9 +77,16 @@ dependencies = [
  "colored",
  "itertools",
  "predicates",
+ "quick-js",
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "cc"
+version = "1.0.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a284da2e6fe2092f2353e51713435363112dfd60030e22add80be333fb928f"
 
 [[package]]
 name = "chrono"
@@ -92,7 +99,7 @@ dependencies = [
  "num-traits",
  "serde",
  "time",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -133,7 +140,16 @@ checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
 dependencies = [
  "atty",
  "lazy_static",
- "winapi",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "copy_dir"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4281031634644843bd2f5aa9c48cf98fc48d6b083bd90bb11becf10deaf8b0"
+dependencies = [
+ "walkdir",
 ]
 
 [[package]]
@@ -213,6 +229,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
+name = "kernel32-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+dependencies = [
+ "winapi 0.2.8",
+ "winapi-build",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -223,6 +249,16 @@ name = "libc"
 version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b2f96d100e1cf1929e7719b7edb3b90ab5298072638fccd77be9ce942ecdfce"
+
+[[package]]
+name = "libquickjs-sys"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f0b24e9bd171b75ae0295bd428fb8fe58410fb23156e5f34a4657a70c3cee96"
+dependencies = [
+ "cc",
+ "copy_dir",
+]
 
 [[package]]
 name = "memchr"
@@ -254,6 +290,12 @@ checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "os_str_bytes"
@@ -325,6 +367,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edc3358ebc67bc8b7fa0c007f945b0b18226f78437d61bec735a9eb96b61ee70"
 dependencies = [
  "unicode-xid",
+]
+
+[[package]]
+name = "quick-js"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19cb4cefcb00f4ab9b332664d06005a74f582ac16aa959c6ad5912957bd83e5f"
+dependencies = [
+ "libquickjs-sys",
+ "once_cell",
 ]
 
 [[package]]
@@ -442,7 +494,7 @@ checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
  "libc",
  "wasi",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -473,10 +525,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66c0b9792f0a765345452775f3adbd28dde9d33f30d13e5dcc5ae17cf6f3780"
+dependencies = [
+ "kernel32-sys",
+ "winapi 0.2.8",
+]
+
+[[package]]
 name = "wasi"
 version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+
+[[package]]
+name = "winapi"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 
 [[package]]
 name = "winapi"
@@ -487,6 +555,12 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -500,7 +574,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ chrono = { version = "0.4.19", features = ["serde"] }
 atty = "0.2.14"
 colored = "2.0.0"
 itertools = "0.10.1"
+quick-js = "0.4.1"
 
 [dev-dependencies]
 assert_cmd = "2.0.2"

--- a/src/level.rs
+++ b/src/level.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 /// Bunyan log level.
 /// Although "named" log levels are specified (see `NamedLogLevel`) arbitrary integer values are
 /// accepted (e.g. 32).
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct NumericalLogLevel(pub u8);
 
 impl FromStr for NumericalLogLevel {
@@ -26,7 +26,7 @@ impl FromStr for NumericalLogLevel {
 /// Although arbitrary integer values are accepted as log levels (see `LogLevel`) the usage of
 /// named log levels is preferred.
 #[repr(u8)]
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum NamedLogLevel {
     /// The service/app is going to stop or become unusable now.
     /// An operator should definitely look into this soon.

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,16 @@ struct Cli {
     /// numeric value.
     #[clap(short, long, default_value = "trace")]
     level: NumericalLogLevel,
+    /// Run each log message through the condition and only show those that return truish.
+    /// E.g.:
+    ///     -c 'this.pid == 123'
+    ///     -c 'this.level == DEBUG'
+    ///     -c 'this.msg.indexOf("boom") != -1'
+    /// "CONDITION" must be (somewhat) legal JS code.
+    /// `this` holds the log record.
+    /// The TRACE, DEBUG, ... FATAL values are defined to help with comparing `this.level`.
+    #[clap(short, long)]
+    condition: Option<String>,
     /// Specify an output format.
     ///
     /// - long: prettified JSON;
@@ -43,5 +53,5 @@ fn main() {
         colored::control::set_override(true);
     }
 
-    process_stdin(cli.output, cli.level.0, cli.strict);
+    process_stdin(cli.output, cli.level.0, cli.condition, cli.strict);
 }

--- a/src/sources/stdin.rs
+++ b/src/sources/stdin.rs
@@ -1,20 +1,33 @@
 use crate::record::LogRecord;
 use crate::Format;
+use quick_js::Context;
 use std::io::BufRead;
 
-pub fn process_stdin(format: Format, level_filter: u8, strict: bool) {
+pub fn process_stdin(format: Format, level_filter: u8, condition: Option<String>, strict: bool) {
     let stdin = std::io::stdin();
+    let context = Context::new().unwrap();
     for line in stdin.lock().lines() {
         let line = line.unwrap();
         match serde_json::from_str::<LogRecord>(&line) {
             Ok(r) => {
-                if r.level >= level_filter {
-                    print!("{}", r.format(format))
+                if r.level < level_filter {
+                    continue;
                 }
+                if let Some(condition) = &condition {
+                    let condition = context
+                        .eval_as::<bool>(
+                            format!("(function (){{return ({condition})}}).call({line})").as_str(),
+                        )
+                        .unwrap();
+                    if !condition {
+                        continue;
+                    }
+                }
+                print!("{}", r.format(format))
             }
             Err(_) => {
                 if !strict {
-                    println!("{}", line)
+                    println!("{line}")
                 }
             }
         }

--- a/src/style.rs
+++ b/src/style.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 /// Supported output formats.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum Format {
     /// Prettified JSON.
     Long,


### PR DESCRIPTION
Add support for filtering logs using `--condition`/`-c` like the Javascript version.

This uses `quick-js` as a very small Javascript interpreter so it would theoretically works the same as the original version, while still being 10x faster 😎