### PR TITLE
Implement nix flake

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -71,3 +71,13 @@ jobs:
         with:
           command: doc
           args: --no-deps --document-private-items
+  nix-build:
+      name: Build with Nix
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout repository
+          uses: actions/checkout@v4
+        - name: Install Nix
+          uses: cachix/install-nix-action@v17
+        - name: Build release
+          run: nix build

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 .idea
+result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,82 @@
+{
+  "nodes": {
+    "crane": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1702141249,
+        "narHash": "sha256-8wDpJKbDTDqFmyJfNEJOLrHYDoEzCjCbmz+lSRoU3CI=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "62fc1a0cbe144c1014d956e603d56bf1ffe69c7d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1702172177,
+        "narHash": "sha256-2T1DjuXz0bVxy5g8oF9FYioHOLWkXw5EdW687NDQakE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2873a73123077953f3e6f34964466018876d87c4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,36 @@
+{
+  description = "A Rust port of node-bunyan";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+    crane.url = "github:ipetkov/crane";
+    crane.inputs.nixpkgs.follows = "nixpkgs";
+
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { crane, nixpkgs, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        craneLib = crane.lib.${system};
+
+        # By default, Crane will only pick up rust-relevant files.
+        # This makes it also include the `.log` files needed for tests.
+        logFileFilter = path: _type: builtins.match ".*log$" path != null;
+        cargoOrLogFilter = path: type:
+          (logFileFilter path type) || (craneLib.filterCargoSources path type);
+      in
+      {
+        packages.default = craneLib.buildPackage
+          {
+            src = pkgs.lib.cleanSourceWith {
+              src = craneLib.path ./.;
+              filter = cargoOrLogFilter;
+            };
+
+            nativeBuildInputs = [ pkgs.libiconv ];
+          };
+      });
+}


### PR DESCRIPTION
## Description

Implement a nix flake.

After this change, people can run the binary with just:
```
nix run github:LukeMathWalker/bunyan
```

Without requiring them to install the Rust toolchain first.

## Testing
You can try this right now on my branch: 

```
programThatProducesLogs | nix run github:jjant/bunyan/nix-flake
```

I've also added a GitHub action that builds the package with Nix.
You can see it ran successfully, [here](https://github.com/jjant/bunyan/actions/runs/7157745013/job/19489021978).

-----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
